### PR TITLE
ci: update publish workflow and release configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,11 @@
-name: Publish
+name: Release & Publish
 
 on:
-  release:
-    types: [ created ]
+  push:
+    branches: [ main ]
 
 jobs:
-  publish:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -19,6 +19,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install
       - run: pnpm run build
-      - run: pnpm publish
+      - run: pnpm release
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,12 @@
     "@semantic-release/changelog",
     "@semantic-release/npm",
     "@semantic-release/github",
-    "@semantic-release/git"
+    [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ]
   ]
 }


### PR DESCRIPTION
- Rename workflow from "Publish" to "Release & Publish"
- Change trigger from release creation to push on main branch
- Replace manual publish step with semantic-release
- Update .releaserc.json to configure git commit message for releases