### PR TITLE
chore(ci): update Node.js and pnpm versions in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9.0.0
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.11.0'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm run typecheck

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9.0.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.11.0'
       - uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9.0.0
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.11.0'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
       - run: pnpm install


### PR DESCRIPTION
- Upgrade pnpm to version 9.0.0 in all workflows
- Update Node.js to version 22.11.0 in all workflows
- Add pnpm and Node.js setup steps to CodeQL workflow
- Minor formatting fix in publish.yml