### PR TITLE
ci: update publish workflow with GitHub App token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,17 +17,29 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.SEMANTIC_RELEASE_APP_ID }}
+          private_key: ${{ secrets.SEMANTIC_RELEASE_PRIVATE_KEY }}
+
       - uses: pnpm/action-setup@v2
         with:
           version: 9.0.0
+
       - uses: actions/setup-node@v4
         with:
           node-version: '22.11.0'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
+
       - run: pnpm install
       - run: pnpm run build
-      - run: pnpm release
+
+      - name: Release
+        run: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Add step to generate GitHub App token for semantic release
- Use generated token for release step instead of GITHUB_TOKEN
- Improve workflow readability with additional newlines